### PR TITLE
Remove support for SSLv3, make SSLv23 the default

### DIFF
--- a/sockschain/__init__.py
+++ b/sockschain/__init__.py
@@ -129,7 +129,6 @@ except ImportError:
 
         class SSL(object):
             SSLv23_METHOD = ssl.PROTOCOL_SSLv23
-            SSLv3_METHOD = ssl.PROTOCOL_SSLv3
             TLSv1_METHOD = ssl.PROTOCOL_TLSv1
             WantReadError = ssl.SSLError
             class Error(Exception): pass
@@ -886,7 +885,7 @@ class socksocket(socket.socket):
         """__negotiatessl(self, destaddr, destport, proxy)
         Negotiates an SSL session.
         """
-        ssl_version = SSL.SSLv3_METHOD
+        ssl_version = SSL.SSLv23_METHOD
         want_hosts = ca_certs = self_cert = None
         ciphers = self.__get_ca_ciphers()
         if anonymous:


### PR DESCRIPTION
SSLv3 is broken: https://en.wikipedia.org/wiki/POODLE
PROTOCOL_SSLv23 is recommended for maximum compatibility with all
versions of SSL/TLS.

Python's inbuilt ssl library has itself switched to SSLv3 in future
versions.
https://bugs.python.org/issue20896
https://hg.python.org/cpython/rev/55f62fa5bebc

Debian has removed the PROTOCOL_SSLv3 constant from its patched version
of Python standard libraries.
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=768611

Other libraries adopting similar appoach:
https://github.com/gevent/gevent/pull/517/files
