### PR TITLE
Python 3 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ setup(
     name = "SocksipyChain",
     version = VERSION,
     description = "A Python SOCKS/HTTP Proxy module",
+    install_requires=["six"],
     long_description = """\
 This Python module allows you to create TCP connections through a chain
 of SOCKS or HTTP proxies without any special effort. It also supports

--- a/sockschain/__init__.py
+++ b/sockschain/__init__.py
@@ -565,11 +565,14 @@ class socksocket(socket.socket):
 
     def makefile(self, mode='r', bufsize=-1):
         self.__makefile_refs += 1
-        try:
-            return socket._fileobject(self, mode, bufsize, close=True)
-        except TypeError:
-            # Python 2.2 compatibility hacks.
-            return socket._fileobject(self, mode, bufsize)
+        if six.PY2:
+            try:
+                return socket._fileobject(self, mode, bufsize, close=True)
+            except TypeError:
+                # Python 2.2 compatibility hacks.
+                return socket._fileobject(self, mode, bufsize)
+        else:
+            return socket.SocketIO(self, mode)
 
     def addproxy(self, proxytype=None, addr=None, port=None, rdns=True, username=None, password=None, certnames=None):
         """setproxy(proxytype, addr[, port[, rdns[, username[, password[, certnames]]]]])

--- a/sockschain/__init__.py
+++ b/sockschain/__init__.py
@@ -46,7 +46,7 @@ mainly to merge bug fixes found in Sourceforge
 
 """
 
-import base64, errno, os, socket, sys, select, struct, threading
+import base64, errno, os, socket, sys, select, struct, threading, six
 DEBUG = False
 #def DEBUG(foo): print foo
 
@@ -659,7 +659,7 @@ class socksocket(socket.socket):
                 # Resolve remotely
                 ipaddr = None
                 req = req + (chr(0x03).encode() +
-                             chr(len(destaddr)).encode() + destaddr)
+                             chr(len(destaddr)).encode() + six.b(destaddr))
             else:
                 # Resolve locally
                 ipaddr = socket.inet_aton(socket.gethostbyname(destaddr))

--- a/test.py
+++ b/test.py
@@ -1,11 +1,18 @@
 #!/usr/bin/python
+from __future__ import print_function
+from six.moves.urllib.request import urlopen
+
 import ftplib
 import telnetlib
-import urllib2
+
+try:
+    import urllib.request as urllib_request  # Python 3
+except ImportError:
+    import urllib2 as urllib_request  # Python 2
 
 # Import SocksiPy
 import sockschain as socks
-def DEBUG(msg): print msg
+def DEBUG(msg): print(msg)
 socks.DEBUG = DEBUG
 
 # Set the proxy information
@@ -13,8 +20,8 @@ socks.DEBUG = DEBUG
 socks.setdefaultproxy(socks.PROXY_TYPE_HTTP, 'klaki.net', 18080)
 
 # Route an HTTP request through the SOCKS proxy 
-socks.wrapmodule(urllib2)
-print urllib2.urlopen('http://bot.whatismyipaddress.com/').read()
+socks.wrapmodule(urllib_request)
+print(urlopen('http://bot.whatismyipaddress.com/').read())
 
 # Route an FTP session through the SOCKS proxy 
 #socks.wrapmodule(ftplib)
@@ -26,5 +33,5 @@ print urllib2.urlopen('http://bot.whatismyipaddress.com/').read()
 # Route a telnet connection through the SOCKS proxy
 socks.wrapmodule(telnetlib)
 tn = telnetlib.Telnet('achaea.com')
-print tn.read_very_eager()
+print(tn.read_very_eager())
 tn.close()


### PR DESCRIPTION
This new pull request is based on the initial effort to make this library Python 3 compatible in PR #6 .

Tests work with a local instance of Danted Socks5 proxy with both Python 2.7 and 3.

Anyone who can test it or provide settings for more testing scenarios, please do.